### PR TITLE
Fix Qordering for Incomplete LU Precond

### DIFF
--- a/examples/uCRM/1_static.cu
+++ b/examples/uCRM/1_static.cu
@@ -3,6 +3,7 @@
 #include "mesh/TACSMeshLoader.h"
 #include "mesh/vtk_writer.h"
 #include "solvers/_solvers.h"
+#include "_src/crm_utils.h"
 
 // shell imports
 #include "assembler.h"
@@ -73,8 +74,13 @@ void solve_linear(MPI_Comm &comm, bool full_LU = true) {
   } else {
     // bsr_data.RCM_reordering();
     // bsr_data.AMD_reordering();
+
+    int lev_fill = 0;
+    // int lev_fill = 1;
+    // int lev_fill = 5;
+
     bsr_data.qorder_reordering(0.5, 1); // qordering not working well for some reason..
-    bsr_data.compute_ILUk_pattern(5, fillin); // 10, 20 (for BiCGStab)
+    bsr_data.compute_ILUk_pattern(lev_fill, fillin); // 10, 20 (for BiCGStab)
     // bsr_data.compute_full_LU_pattern(fillin, print);
   }
   assembler.moveBsrDataToDevice();

--- a/include/linalg/bsr_data.h
+++ b/include/linalg/bsr_data.h
@@ -319,10 +319,11 @@ class BsrData {
         std::random_device rd;  // random number generator
         std::mt19937 g(rd());
         // since iperm is used for sparsity change now, qperm modifies that
-        std::vector<int> q_perm(perm, perm + nnodes);
+        // std::vector<int> q_perm(perm, perm + nnodes);
+        std::vector<int> q_perm(iperm, iperm + nnodes);
         for (int iprune = 0; iprune < num_prunes; iprune++) {
             int lower = prune_width * iprune;
-            int upper = std::min(lower + prune_width, nnodes);
+            int upper = std::min(lower + prune_width, nnodes-1);
             std::shuffle(q_perm.begin() + lower, q_perm.begin() + upper, g);
         }
 
@@ -335,12 +336,12 @@ class BsrData {
 
         // update final permutation and iperm (deep copy)
         for (int i = 0; i < nnodes; i++) {
-            perm[i] = q_perm[i];
-            iperm[q_perm[i]] = i;
+            // perm[i] = q_perm[i];
+            // iperm[q_perm[i]] = i;
 
             // try swapping perm, iperm
-            // iperm[i] = q_perm[i];
-            // perm[q_perm[i]] = i;
+            iperm[i] = q_perm[i];
+            perm[q_perm[i]] = i;
         }
     }
 

--- a/tests/reordering/3_qordering.cpp
+++ b/tests/reordering/3_qordering.cpp
@@ -1,2 +1,36 @@
 // TODO: maybe check bandwidth still reduced, somehow check chain lengths
 // or save reference qordering when I got it working right (rowp, cols and check against that)
+
+#include "../test_commons.h"
+#include "linalg/bsr_data.h"
+
+int main() {
+    // inputs
+    int num_rcm_iters = 6;  // try higher number
+    bool print = false;
+    // -----------------
+
+    constexpr int n = 7, nnz = 18;
+    int rowp[n + 1] = {0, 3, 5, 8, 12, 14, 16, 18};
+    int cols[nnz] = {1, 3, 4, 0, 2, 1, 3, 5, 0, 2, 5, 6, 0, 6, 2, 3, 3, 4};
+
+    // reference RCM reordering from baseline/rcm.py (using scipy)
+    int scipy_perm[n] = {6, 5, 3, 4, 2, 0, 1};
+    int new_rowp[n + 1] = {0, 2, 4, 8, 10, 13, 16, 18};
+    int new_cols[nnz] = {2, 3, 2, 4, 0, 1, 4, 5, 0, 5, 1, 2, 6, 2, 3, 6, 4, 5};
+
+    // bandwidth changes from 4 to 3 in python, could check this also..
+    int orig_bandwidth = BsrData::getBandWidth(n, nnz, rowp, cols);
+
+    // our RCM method is slightly different from scipy, so here we just check we get the same matrix
+    // bandwidth, which is reduced to 3 (different tie breaking strategies)
+    int block_dim = 1;
+    auto bsr_data = BsrData(n, block_dim, nnz, rowp, cols);
+    bsr_data.qorder_reordering(1.0, num_rcm_iters);
+    bsr_data.compute_nofill_pattern();
+    int new_bandwidth = BsrData::getBandWidth(n, nnz, bsr_data.rowp, bsr_data.cols);
+    if (print) {
+        printf("with our qorder method (slightly different than scipy)\n");
+        printf("\tbandwidth reduces from %d to %d\n", orig_bandwidth, new_bandwidth);
+    }
+}


### PR DESCRIPTION
* got same matrix that Kevin and Kyle used to solve TACS in their node numbering paper with q(0.5) and ILU(0) or ILU(1) precond
* goal is to recreate this result in TACS and get the most speedup possible with qordering on the GPU